### PR TITLE
🐛 Fix bugs in release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           git fetch origin main:main
           git fetch --all --tags --force
           if ! git merge-base --is-ancestor "$RELEASE_TAG" main; then
-            echo "# Invalid release tag [$RELEASE_TAG] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            echo "# Invalid release tag [$RELEASE_TAG] - must be on main" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
       - run: |-
@@ -63,7 +63,7 @@ jobs:
     needs:
       - ci
       - version
-    if: github.ref == 'refs/heads/main' && github.event.release
+    if: github.event.release
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -88,4 +88,4 @@ jobs:
           context: .
           platforms: "${{ env.CONTAINER_ARCHS }}"
           push: true
-          tags: ghcr.io/opentdf/gokas:${{ steps.version.outputs.VERSION }}
+          tags: ghcr.io/opentdf/gokas:${{ needs.version.outputs.VERSION }}


### PR DESCRIPTION
- 'version' already checks to make sure 'release' is on main, so we don't need that check later
- github.ref will always be a tag, never the branch, so we can't use the expression here anyway
- fix an incorrect reference for the 'tag' of the generated file