### PR TITLE
✨ Updates container to match python kas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /backend-go
 /kas
 /go-kas
+gokas

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ COPY go.sum ./
 COPY makefile ./
 COPY cmd/ cmd/
 COPY internal/ internal/
-COPY mocks/ mocks/
 COPY pkg/ pkg/
 RUN go list -m -u all
 RUN make test
@@ -33,6 +32,10 @@ ENV SERVICE "default"
 RUN apt-get update -y && apt-get install -y softhsm opensc openssl
 COPY --from=builder /build/gokas /
 COPY scripts/ scripts/
+COPY softhsm2-debug.conf /etc/softhsm/softhsm2.conf
+RUN chmod +x /etc/softhsm
+RUN mkdir -p /secrets
+RUN chown 10001 /secrets
 ENTRYPOINT ["/scripts/run.sh"]
 
 # server - production
@@ -59,4 +62,8 @@ RUN apt-get update -y && apt-get install -y softhsm opensc openssl
 
 COPY --from=builder /build/gokas /
 COPY scripts/ /scripts/
+COPY softhsm2-prod.conf /etc/softhsm/softhsm2.conf
+RUN chmod +x /etc/softhsm
+RUN mkdir -p /secrets
+RUN chown 10001 /secrets
 ENTRYPOINT ["/scripts/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,11 @@ COPY go.mod ./
 COPY go.sum ./
 COPY makefile ./
 COPY cmd/ cmd/
+COPY internal/ internal/
 COPY mocks/ mocks/
 COPY pkg/ pkg/
-# dependency
 RUN go list -m -u all
-#  static analysis
-RUN go vet ./...
-# test and benchmark
-RUN go test -bench=. -benchmem ./...
-# race condition
-RUN make gokas
+RUN make test
 
 # server-debug - root
 FROM ubuntu:latest as server-debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,23 @@ ARG GO_VERSION=latest
 # builder - executable for deployment
 # reference https://hub.docker.com/_/golang
 FROM golang:$GO_VERSION as builder
-# reference https://medium.com/@lizrice/non-privileged-containers-based-on-the-scratch-image-a80105d6d341
-RUN useradd -u 10001 scratchuser
 WORKDIR /build/
-COPY . ./
+COPY go.mod ./
+COPY go.sum ./
+COPY makefile ./
 COPY cmd/ cmd/
+COPY internal/ internal/
 COPY pkg/ pkg/
-RUN CGO_ENABLED=1 GOOS=linux go build -v -a -installsuffix cgo -o . ./...
+RUN make gokas
 
 # tester
 FROM golang:$GO_VERSION as tester
 WORKDIR /test/
-COPY . ./
+COPY go.mod ./
+COPY go.sum ./
+COPY makefile ./
 COPY cmd/ cmd/
+COPY mocks/ mocks/
 COPY pkg/ pkg/
 # dependency
 RUN go list -m -u all
@@ -26,38 +30,26 @@ RUN go vet ./...
 # test and benchmark
 RUN go test -bench=. -benchmem ./...
 # race condition
-RUN CGO_ENABLED=1 GOOS=linux go build -v -a -race -installsuffix cgo -o . ./...
+RUN make gokas
 
 # server-debug - root
 FROM ubuntu:latest as server-debug
-EXPOSE 8080
-ENTRYPOINT ["/microservice"]
 ENV SERVICE "default"
-COPY --from=builder /build/microservice /
+RUN apt-get update -y && apt-get install -y softhsm opensc openssl
+COPY --from=builder /build/gokas /
+COPY scripts/ scripts/
+ENTRYPOINT ["/scripts/run.sh"]
 
 # server - production
-FROM scratch as server
-USER scratchuser
-EXPOSE 8080
-ENTRYPOINT ["/microservice"]
+FROM ubuntu:latest as server
 ENV SERVICE "default"
 # Server
 ENV SERVER_ROOT_PATH "/"
 ENV SERVER_PORT "4020"
 ENV SERVER_PUBLIC_NAME ""
 ENV SERVER_LOG_LEVEL "INFO"
-# Postgres
-ENV POSTGRES_HOST ""
-ENV POSTGRES_PORT "5432"
-ENV POSTGRES_USER ""
-ENV POSTGRES_PASSWORD ""
-ENV POSTGRES_DATABASE ""
-ENV POSTGRES_SCHEMA "tdf_attribute"
-# OIDC
-ENV OIDC_CLIENT_ID ""
-ENV OIDC_CLIENT_SECRET ""
-ENV OIDC_REALM ""
 ## trailing / is required
+ENV OIDC_ISSUER ""
 ENV OIDC_SERVER_URL ""
 ENV OIDC_AUTHORIZATION_URL ""
 ENV OIDC_TOKEN_URL ""
@@ -68,5 +60,8 @@ ENV PKCS11_PIN ""
 ENV PKCS11_SLOT_INDEX ""
 ENV PKCS11_LABEL_PUBKEY_RSA ""
 ENV PKCS11_LABEL_PUBKEY_EC ""
-COPY --from=builder /build/microservice /
-COPY --from=builder /etc/passwd /etc/passwd
+RUN apt-get update -y && apt-get install -y softhsm opensc openssl
+
+COPY --from=builder /build/gokas /
+COPY scripts/ /scripts/
+ENTRYPOINT ["/scripts/run.sh"]

--- a/makefile
+++ b/makefile
@@ -1,4 +1,7 @@
-APP_NAME = "go-kas"
+.PHONY: all clean
+
+all: gokas
+
 GO_MOD_LINE = $(shell head -n 1 go.mod | cut -c 8-)
 GO_MOD_NAME = ${GO_MOD_LINE}
 CONF_PATH = ${GO_MOD_NAME}/internal/conf
@@ -7,10 +10,10 @@ BUILD_TIME = $(shell date +'%Y-%m-%d_%T')
 SHA1 = $(shell git rev-parse HEAD)
 MAIN_FILE = cmd/microservice/main.go
 
-BUILD_DIR=build
-update-doc: 
-	swag init -d api
-build:
-	go build -ldflags '-X ${CONF_PATH}.Version=${VERSION} -X ${CONF_PATH}.Sha1=${SHA1} -X ${CONF_PATH}.BuildTime=${BUILD_TIME}' -o ${BUILD_DIR}/${APP_NAME} ${MAIN_FILE}
+# TODO: Fix swagger generation
+# update-doc: 
+# 	swag init -d api
+gokas:
+	go build -ldflags '-X ${CONF_PATH}.Version=${VERSION} -X ${CONF_PATH}.Sha1=${SHA1} -X ${CONF_PATH}.BuildTime=${BUILD_TIME}' -o gokas ${MAIN_FILE}
 clean:
-	rm -rf ${BUILD_DIR}
+	rm -f gokas

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean
+.PHONY: all clean test
 
 all: gokas
 
@@ -17,3 +17,6 @@ gokas:
 	go build -ldflags '-X ${CONF_PATH}.Version=${VERSION} -X ${CONF_PATH}.Sha1=${SHA1} -X ${CONF_PATH}.BuildTime=${BUILD_TIME}' -o gokas ${MAIN_FILE}
 clean:
 	rm -f gokas
+test: gokas
+	go vet ./...
+	go test -bench=. -benchmem ./...

--- a/scripts/clean-hsm.sh
+++ b/scripts/clean-hsm.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+# Use ./scripts/clean-hsm.sh
+
+: "${PKCS11_TOKEN_LABEL:=development-token}"
+softhsm2-util --delete-token --token "${PKCS11_TOKEN_LABEL}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,7 +5,7 @@
 #
 # Environment variables:
 #   OIDC_ISSUER
-#     - 
+#     -
 #   PKCS11_PIN
 #     - SECRET
 #     - local PIN for pkcs11. will be generated if not present
@@ -98,9 +98,9 @@ fi
 : "${PKCS11_LABEL_PUBKEY_RSA:=development-rsa-kas}"
 : "${PKCS11_LABEL_PUBKEY_EC:=development-ec-kas}"
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+if [[ $OSTYPE == "linux-gnu"* ]]; then
   : "${PKCS11_MODULE_PATH:=/lib/softhsm/libsofthsm2.so}"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif [[ $OSTYPE == "darwin"* ]]; then
   : "${PKCS11_MODULE_PATH:=$(brew --prefix)/lib/softhsm/libsofthsm2.so}"
 else
   monolog ERROR "Unknown OS [${OSTYPE}]"
@@ -135,9 +135,6 @@ softhsm2-util --init-token --slot "${PKCS11_SLOT_INDEX}" --label "${PKCS11_TOKEN
 pkcs11-tool "${MODULE_ARGS[@]}" --show-info --list-objects ||
   e "Unable to list objects with pkcs11-tool; continuing"
 
-
-
-
 ptool=(pkcs11-tool "${MODULE_ARGS[@]}" --login --pin "${PKCS11_PIN}")
 
 if [ -z "${KAS_PRIVATE_KEY}" ]; then
@@ -147,12 +144,12 @@ if [ -z "${KAS_PRIVATE_KEY}" ]; then
     fi
     l "Importing KAS private key from files kas-{cert,private}.pem"
     "${ptool[@]}" --write-object kas-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_RSA}"
-    "${ptool[@]}" --write-object kas-cert.pem    --type cert    --label "${PKCS11_LABEL_PUBKEY_RSA}"
+    "${ptool[@]}" --write-object kas-cert.pem --type cert --label "${PKCS11_LABEL_PUBKEY_RSA}"
   else
     w "Creating new KAS private key - missing parameter KAS_PRIVATE_KEY"
     openssl req -x509 -nodes -newkey RSA:2048 -subj "/CN=kas" -keyout kas-private.pem -out kas-cert.pem -days 365
     "${ptool[@]}" --write-object kas-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_RSA}"
-    "${ptool[@]}" --write-object kas-cert.pem    --type cert    --label "${PKCS11_LABEL_PUBKEY_RSA}"
+    "${ptool[@]}" --write-object kas-cert.pem --type cert --label "${PKCS11_LABEL_PUBKEY_RSA}"
   fi
 elif [ -z "${KAS_CERTIFICATE}" ]; then
   e "Missing KAS_CERTIFICATE"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Use ./scripts/run.sh [host]
+# Parameters:
+#   Optional parameter: port or host to expose. Defaults to 8000
+#
+# Environment variables:
+#   OIDC_ISSUER
+#     - 
+#   PKCS11_PIN
+#     - SECRET
+#     - local PIN for pkcs11. will be generated if not present
+#   PKCS11_SO_PIN
+#     - SECRET
+#     - SO PIN for pkcs11. will be generated if not present
+#   KAS_PRIVATE_KEY
+#     - SECRET
+#     - Private key (SECRET) KAS uses to certify responses.
+#   KAS_CERTIFICATE
+#     - SECRET
+#     - Public key KAS clients can use to validate responses.
+#   ATTR_AUTHORITY_HOST
+#     - OpenTDF Attribute service host, or other compliant authority
+#   ATTR_AUTHORITY_CERTIFICATE
+#     - The public key used to validate responses from ATTR_AUTHORITY_HOST.
+
+#   Not Implemented or used Yet
+#   OIDC_SERVER_URL
+#     - FIXME
+#     - List of allowed prefixes for OIDC tokens
+#   LOGLEVEL
+#     - Verbosity of default log handler. Should recognize python log levels
+#   JSON_LOGGER
+#     - if to enable json mode of log output. 'true' enabled json output
+#   KAS_EC_SECP256R1_PRIVATE_KEY
+#     - (SECRET) private key of curve secp256r1, KAS uses to certify responses.
+#     - required for nanoTDF
+#   KAS_EC_SECP256R1_CERTIFICATE
+#     - The public key of curve secp256r1, KAS clients can use
+#       to validate responses.
+#     - required for nanoTDF
+#   AUDIT_ENABLED
+#   CA_CERT_PATH
+#     -
+#
+#   Maybe will not implement?
+#   USE_OIDC
+#   CLIENT_CERT_PATH
+#   CLIENT_KEY_PATH
+#   V2_SAAS_ENABLED
+#   LEGACY_NANOTDF_IV
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPTS_DIR}/../" >/dev/null && pwd)"
+
+e() {
+  echo ERROR "${@}"
+  exit 1
+}
+
+l() {
+  echo INFO "${@}"
+}
+
+w() {
+  echo WARNING "${@}"
+}
+
+# Configure and validate HOST variable
+# This should be of the form [port] or [https://host:port/], for example
+if [ -z "$1" ]; then
+  HOST=https://localhost:8000/
+elif [[ $1 == *" "* ]]; then
+  e "Invalid hostname: [$1]"
+elif [[ $1 == http?:* ]]; then
+  HOST="$1":8000
+elif [[ $1 == http?:*:* ]]; then
+  HOST="$1"
+elif [[ $1 =~ ^[0-9]+$ ]]; then
+  HOST=https://localhost:$1/
+else
+  e "Invalid hostname or port: [$1]"
+fi
+export HOST
+
+l "Configuring ${HOST}..."
+
+if [ -z "$OIDC_SERVER_URL" ]; then
+  : "${OIDC_ISSUER:=${OIDC_SERVER_URL}/realms/tdf}"
+else
+  : "${OIDC_ISSUER:=https://localhost:65432/auth/realms/tdf}"
+fi
+
+: "${PKCS11_SLOT_INDEX:=0}"
+: "${PKCS11_TOKEN_LABEL:=development-token}"
+# FIXME random or error out if not set
+: "${PKCS11_PIN:=12345}"
+: "${PKCS11_SO_PIN:=12345}"
+: "${PKCS11_LABEL_PUBKEY_RSA:=development-rsa-kas}"
+: "${PKCS11_LABEL_PUBKEY_EC:=development-ec-kas}"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  : "${PKCS11_MODULE_PATH:=/lib/softhsm/libsofthsm2.so}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  : "${PKCS11_MODULE_PATH:=$(brew --prefix)/lib/softhsm/libsofthsm2.so}"
+else
+  monolog ERROR "Unknown OS [${OSTYPE}]"
+  exit 1
+fi
+
+MODULE_ARG="--allow-sw"
+
+if [ -f "${PKCS11_MODULE_PATH}" ]; then
+  l "Using PKCS11 module ${PKCS11_MODULE_PATH}"
+  MODULE_ARG="--module=${PKCS11_MODULE_PATH}"
+else
+  l "Using PKCS11 with default --allow-sw"
+fi
+
+export OIDC_ISSUER
+l "{host: '${HOST}', issuer: '${OIDC_ISSUER}', slot: ${PKCS11_SLOT_INDEX}, tokenLabel: '${PKCS11_TOKEN_LABEL}', modulePath: '${PKCS11_MODULE_PATH}'}"
+
+if pkcs11-tool "${MODULE_ARG}" --show-info --list-objects; then
+  e "pkcs11-tool indicates softhsm already inited; run 'softhsm2-util --delete-token --token ${PKCS11_TOKEN_LABEL}' or similar to delete"
+fi
+l "Unable to list objects with pkcs11-tool before init"
+
+# Configure softhsm. This is used to store secrets in an HSM compatible way
+# softhsm2-util --init-token --slot 0 --label "development-token" --pin $PKCS11_PIN --so-pin $HSM_SO_PIN
+softhsm2-util --init-token --slot="${PKCS11_SLOT_INDEX}" --label="${PKCS11_TOKEN_LABEL}" --pin="${PKCS11_PIN}" --so-pin="${PKCS11_SO_PIN}" ||
+  e "Unable to use softhsm to init [--slot ${PKCS11_SLOT_INDEX} --label ${PKCS11_TOKEN_LABEL}]"
+
+# verify login
+pkcs11-tool "${MODULE_ARG}" --show-info --list-objects ||
+  e "Unable to list objects with pkcs11-tool; continuing"
+
+
+
+
+ptool=(pkcs11-tool "${MODULE_ARG}" --login --pin="${PKCS11_PIN}")
+
+if [ -z "${KAS_PRIVATE_KEY}" ]; then
+  if [ -f kas-private.pem ]; then
+    if [ ! -f kas-cert.pem ]; then
+      e "Missing kas-cert.pem"
+    fi
+    l "Importing KAS private key from files kas-{cert,private}.pem"
+    "${ptool[@]}" --write-object kas-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_RSA}"
+    "${ptool[@]}" --write-object kas-cert.pem    --type cert    --label "${PKCS11_LABEL_PUBKEY_RSA}"
+  else
+    w "Creating new KAS private key - missing parameter KAS_PRIVATE_KEY"
+    openssl req -x509 -nodes -newkey RSA:2048 -subj "/CN=kas" -keyout kas-private.pem -out kas-cert.pem -days 365
+    "${ptool[@]}" --write-object kas-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_RSA}"
+    "${ptool[@]}" --write-object kas-cert.pem    --type cert    --label "${PKCS11_LABEL_PUBKEY_RSA}"
+  fi
+elif [ -z "${KAS_CERTIFICATE}" ]; then
+  e "Missing KAS_CERTIFICATE"
+else
+  l "Importing KAS private key (RSA)"
+  "${ptool[@]}" --write-object <(echo "${KAS_PRIVATE_KEY}") --type privkey --label "${PKCS11_LABEL_PUBKEY_RSA}"
+  "${ptool[@]}" --write-object <(echo "${KAS_CERTIFICATE}") --type cert --label "${PKCS11_LABEL_PUBKEY_RSA}"
+fi
+
+if [ -z "${KAS_EC_SECP256R1_PRIVATE_KEY}" ]; then
+  if [ -f kas-ec-private.pem ]; then
+    if [ ! -f kas-ec-cert.pem ]; then
+      e "Missing kas-ec-cert.pem"
+    fi
+    l "Importing KAS private key from file"
+    # import EC key to PKCS
+    "${ptool[@]}" --write-object kas-ec-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_EC}"
+    # import EC cert to PKCS
+    "${ptool[@]}" --write-object kas-ec-cert.pem --type cert --label "${PKCS11_LABEL_PUBKEY_EC}"
+  else
+    w "Creating new KAS private key - missing parameter KAS_EC_SECP256R1_PRIVATE_KEY"
+    # create EC key and cert
+    openssl req -x509 -nodes -newkey ec:<(openssl ecparam -name prime256v1) -subj "/CN=kas" -keyout kas-ec-private.pem -out kas-ec-cert.pem -days 365
+    # import EC key to PKCS
+    "${ptool[@]}" --write-object kas-ec-private.pem --type privkey --label "${PKCS11_LABEL_PUBKEY_EC}"
+    # import EC cert to PKCS
+    "${ptool[@]}" --write-object kas-ec-cert.pem --type cert --label "${PKCS11_LABEL_PUBKEY_EC}"
+  fi
+elif [ -z "${KAS_EC_SECP256R1_CERTIFICATE}" ]; then
+  e "Missing KAS_EC_SECP256R1_CERTIFICATE"
+else
+  l "Importing KAS private key (EC)"
+  "${ptool[@]}" --write-object <(echo "$KAS_EC_SECP256R1_PRIVATE_KEY") --type privkey --label "${PKCS11_LABEL_PUBKEY_EC}"
+  "${ptool[@]}" --write-object <(echo "$KAS_EC_SECP256R1_CERTIFICATE") --type cert --label "${PKCS11_LABEL_PUBKEY_EC}"
+fi
+
+l "Starting..."
+"${PROJECT_ROOT}/gokas"

--- a/softhsm2-debug.conf
+++ b/softhsm2-debug.conf
@@ -1,0 +1,16 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = /secrets/tokens/
+objectstore.backend = file
+
+# ERROR, WARNING, INFO, DEBUG
+log.level = DEBUG
+
+# If CKF_REMOVABLE_DEVICE flag should be set
+slots.removable = false
+
+# Enable and disable PKCS#11 mechanisms using slots.mechanisms.
+slots.mechanisms = ALL
+
+# If the library should reset the state on fork
+library.reset_on_fork = false

--- a/softhsm2-prod.conf
+++ b/softhsm2-prod.conf
@@ -1,0 +1,16 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = /secrets/tokens/
+objectstore.backend = file
+
+# ERROR, WARNING, INFO, DEBUG
+log.level = ERROR
+
+# If CKF_REMOVABLE_DEVICE flag should be set
+slots.removable = false
+
+# Enable and disable PKCS#11 mechanisms using slots.mechanisms.
+slots.mechanisms = ALL
+
+# If the library should reset the state on fork
+library.reset_on_fork = false


### PR DESCRIPTION
- Adds soft-hsm to containers by default
- Adds `run.sh` script to convert from python KAS configuration environment variables to gokas variables and import the secrets into the HSM
- Renames and rehomes go binary to root to match most go projects
- Fixes ownership so it runs as user 10001, our current preferred use in quickstart

Caveats:

- For now, only supports soft-hsm
- Binary is `gokas` but really should. be just `kas`, right?
- I'm just using ubuntu:latest, but this should be slim and pinned, right?