### PR TITLE
🧼  Cleanups of port and middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ gokas
 
 # test data
 .github/workflows/roundtrip/sample.*
+
+# Mock certs
+kas-cert.pem
+kas-ec-cert.pem
+kas-ec-private.pem
+kas-private.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV LOG_FORMAT "TEXT"
 ENV KAS_URL ""
 ENV PKCS11_SLOT_INDEX "0"
 ENV AUDIT_ENABLED=false
+ENV SERVER_HTTP_PORT 8000
 RUN apt-get update -y && apt-get install -y softhsm opensc openssl
 COPY --from=builder /build/gokas /
 COPY scripts/ scripts/
@@ -53,6 +54,8 @@ ENV SERVICE "default"
 ENV LOG_LEVEL "INFO"
 ENV LOG_FORMAT "JSON"
 ENV KAS_URL ""
+ENV AUDIT_ENABLED=false
+ENV SERVER_HTTP_PORT 8000
 ## trailing / is required
 ENV OIDC_DISCOVERY_BASE_URL ""
 ENV OIDC_ISSUER_URL ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # backend-go
+
 Key Access Service Go implementation supporting [Trusted Data Format Protocol](https://github.com/opentdf/spec) 
 
 ## Prerequisites
@@ -69,6 +70,7 @@ brew install softhsm
 # get module path
 brew info softhsm
 # /opt/homebrew/Cellar/softhsm/2.6.1  will be  /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so
+# FIXME: How can we extract the path from brew???
 export PKCS11_MODULE_PATH=/opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so
 # installs pkcs11-tool
 brew install opensc
@@ -86,13 +88,13 @@ openssl req -x509 -nodes -newkey RSA:2048 -subj "/CN=kas" -keyout kas-private.pe
 # crease EC key and cert
 openssl req -x509 -nodes -newkey ec:<(openssl ecparam -name prime256v1) -subj "/CN=kas" -keyout kas-ec-private.pem -out kas-ec-cert.pem -days 365
 # import RSA key to PKCS
-pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-private.pem --type privkey --id 100 --label development-rsa-kas
+pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-private.pem --type privkey --label development-rsa-kas
 # import RSA cert to PKCS
-pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-cert.pem --type cert --id 100 --label development-rsa-kas
+pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-cert.pem --type cert --label development-rsa-kas
 # import EC key to PKCS
-pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-private.pem --type privkey --id 200 --label development-ec-kas
+pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-private.pem --type privkey --label development-ec-kas
 # import EC cert to PKCS
-pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-cert.pem --type cert --id 200 --label development-ec-kas
+pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-cert.pem --type cert  --label development-ec-kas
 ```
 
 ### Start services
@@ -128,6 +130,7 @@ brew install act golangci-lint
 ```
 
 Tools
+
 - https://www.docker.com
 - https://github.com/nektos/act
 - https://github.com/golangci/golangci-lint
@@ -173,41 +176,52 @@ docker run -it --volume "$PWD":/workdir ksc:0.8 \
 ## References
 
 ### Helm
+
 https://helm.sh/docs/chart_template_guide/subcharts_and_globals/  
 https://faun.pub/helm-chart-how-to-create-helm-charts-from-kubernetes-k8s-yaml-from-scratch-d64901e36850  
 https://github.com/kubernetes/examples/blob/master/guidelines.md  
 
 ### Go
+
 https://github.com/powerman/go-monolith-example  
 https://github.com/getkin/kin-openapi  
 
 ### Docker
+
 https://docs.docker.com/develop/develop-images/multistage-build/  
 https://medium.com/@lizrice/non-privileged-containers-based-on-the-scratch-image-a80105d6d341  
 
 ### Tilt
+
 https://dev.to/ndrean/rails-on-kubernetes-with-minikube-and-tilt-25ka  
 
 ### PostgreSQL
+
 https://dev.to/kushagra_mehta/postgresql-with-go-in-2021-3dfg  
 https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach/24326540#24326540  
 
 ### minikube
+
 https://minikube.sigs.k8s.io/docs/handbook/host-access/  
 
 ### OIDC
+
 https://github.com/coreos/go-oidc  
 
 ### Ingress
+
 https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/  
 
 ### KMIP  
+
 https://github.com/ThalesGroup/kmip-go
 
 ### pkcs11-tool  
+
 https://verschlüsselt.it/generate-rsa-ecc-and-aes-keys-with-opensc-pkcs11-tool/
 
 ### go-util  
+
 https://github.com/gbolo/go-util  
 https://github.com/gbolo/go-util/tree/master/pkcs11-test
 
@@ -216,6 +230,7 @@ https://github.com/gbolo/go-util/tree/master/pkcs11-test
 https://github.com/psmiraglia/docker-softhsm
 
 ### For local running please start backend following instructions
+
 https://github.com/opentdf/opentdf/tree/main/quickstart
 
 ```shell
@@ -235,6 +250,7 @@ pkcs11-tool --module $PKCS11_MODULE_PATH --login --show-info --list-objects
 ```
 
 ### Following that steps run the "show info" command
+
 ```shell
 pkcs11-tool --module $PKCS11_MODULE_PATH --login --show-info --list-objects
 ```

--- a/cmd/microservice/main_test.go
+++ b/cmd/microservice/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 )
@@ -76,5 +77,24 @@ func TestInferLogLevel(t *testing.T) {
 	}
 	if h.Enabled(context.Background(), slog.LevelWarn) {
 		t.Error("should not be at warn")
+	}
+}
+
+func TestValidatePort(t *testing.T) {
+	p, err := validatePort("")
+	if p != 0 || err != nil {
+		t.Error("empty SERVER_PORT should default properly")
+	}
+	p, err = validatePort("invalid")
+	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+		t.Error("invalid error code")
+	}
+	p, err = validatePort("-1000")
+	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+		t.Error("invalid error code")
+	}
+	p, err = validatePort("65536")
+	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+		t.Error("invalid error code")
 	}
 }

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 .PHONY: all clean test
 
 all: gokas
+go-plugins: plugins/audit_hooks.so
 
 GO_MOD_LINE = $(shell head -n 1 go.mod | cut -c 8-)
 GO_MOD_NAME = ${GO_MOD_LINE}
@@ -15,10 +16,14 @@ MAIN_FILE = cmd/microservice/main.go
 # 	swag init -d api
 gokas: $(shell find . -name "*.go" -and -not -path '*/dist*' -and -not -path '*/coverage*' -and -not -path '*/node_modules*')
 	go build -ldflags '-X ${CONF_PATH}.Version=${VERSION} -X ${CONF_PATH}.Sha1=${SHA1} -X ${CONF_PATH}.BuildTime=${BUILD_TIME}' -o gokas ${MAIN_FILE}
-go-plugins:
+
+plugins/audit_hooks.so: $(shell find plugins -name "*.go")
 	go build -buildmode=plugin -o="plugins/" plugins/**
+
 clean:
 	rm -f gokas
+	find plugins -type f -name '*.so' | xargs rm
+
 test: gokas
 	go vet ./...
 	go test -bench=. -benchmem ./...

--- a/opentdf.Tiltfile
+++ b/opentdf.Tiltfile
@@ -13,7 +13,7 @@ min_tilt_version("0.31")
 EXTERNAL_URL = "http://localhost:65432"
 
 # Versions of things backend to pull (attributes, kas, etc)
-BACKEND_CHART_TAG = os.environ.get("BACKEND_LATEST_VERSION", "0.0.0-sha-27d776c")
+BACKEND_CHART_TAG = os.environ.get("BACKEND_LATEST_VERSION", "0.0.0-sha-02d27b5")
 FRONTEND_CHART_TAG = os.environ.get("FRONTEND_LATEST_VERSION", "1.4.1")
 
 CONTAINER_REGISTRY = os.environ.get("CONTAINER_REGISTRY", "ghcr.io")
@@ -115,7 +115,12 @@ def backend(values=[], set={}, resource_deps=[]):
     )
     for x in ["attributes", "entitlement-store"]:
         k8s_resource(x, labels="opentdf", resource_deps=["postgresql"])
-    k8s_resource("kas", labels="opentdf", resource_deps=["attributes", "keycloak"])
+    k8s_resource(
+        "kas",
+        labels="opentdf",
+        resource_deps=["attributes", "keycloak"],
+        port_forwards="9000:5000"
+    )
 
 
 def frontend(values=[], set={}, resource_deps=[]):
@@ -143,7 +148,7 @@ def opentdf_cluster_with_ingress(start_frontend=True):
                 "entitlement-store",
             ]
         },
-        # values=[TESTS_DIR + "/mocks/values.yaml"],
+        values=[TESTS_DIR + "/mocks/values.yaml"],
         resource_deps=["ingress-nginx"],
     )
 

--- a/plugins/audit_hooks.go
+++ b/plugins/audit_hooks.go
@@ -174,7 +174,7 @@ func (g a) AuditHook(next http.Handler) http.Handler {
 		processedAuditLogAsString := fmt.Sprintf("%+v", auditLog)
 		auditHookLogger.Info("Processed AuditLog", "auditLog", processedAuditLogAsString)
 
-		next(w, r)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/plugins/audit_hooks.go
+++ b/plugins/audit_hooks.go
@@ -126,7 +126,7 @@ func CreateLogger() (*slog.Logger, error) {
 	return logger, nil
 }
 
-func (g a) AuditHook(next http.HandlerFunc) http.HandlerFunc {
+func (g a) AuditHook(next http.Handler) http.Handler {
 	logger, err := CreateLogger()
 	if err != nil {
 		panic(err)
@@ -160,7 +160,7 @@ func (g a) AuditHook(next http.HandlerFunc) http.HandlerFunc {
 
 	auditLog.tdfAttributes.attrs = append(auditLog.tdfAttributes.attrs, policy.exportRaw()...)
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auditHookLogger.Info("HTTP request", "Method", r.Method, "Url", r.URL.Path)
 
 		auditLog.tdfAttributes.dissem = policy.dissem
@@ -175,7 +175,7 @@ func (g a) AuditHook(next http.HandlerFunc) http.HandlerFunc {
 		auditHookLogger.Info("Processed AuditLog", "auditLog", processedAuditLogAsString)
 
 		next(w, r)
-	}
+	})
 }
 
 func ErrAuditHook(err string) {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -x
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+HOST=https://localhost:5000/
+LOG_FORMAT=dev
+OIDC_ISSUER_URL=http:///localhost:65432/auth/realms/tdf
+PKCS11_SLOT_INDEX=1
+
+export HOST
+export LOG_FORMAT
+export OIDC_ISSUER_URL
+export PKCS11_SLOT_INDEX
+
+openssl req -x509 -nodes -newkey RSA:2048 -subj "/CN=kas" -keyout kas-private.pem -out kas-cert.pem -days 365
+openssl req -x509 -nodes -newkey ec:<(openssl ecparam -name prime256v1) -subj "/CN=kas" -keyout kas-ec-private.pem -out kas-ec-cert.pem -days 365
+
+"${SCRIPTS_DIR}/run.sh"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,6 +6,8 @@
 # Environment variables:
 #   KAS_URL
 #     - The URL prefix this KAS is served from, including origin
+#   SERVER_HTTP_PORT
+#     - The port to serve the HTTP REST endpoint on
 #   OIDC_ISSUER_URL
 #     - The URL prefix to check for ISSUER. Also used for oidc discovery, 
 #       unless overridden by OIDC_DISCOVERY_BASE_URL
@@ -71,22 +73,27 @@ w() {
   echo WARNING "${@}"
 }
 
+: "${SERVER_HTTP_PORT:=8000}"
+
 # Configure and validate HOST variable
 # This should be of the form [port] or [https://host:port/], for example
 if [ -z "$1" ]; then
-  HOST=https://localhost:8000/
+  HOST=https://localhost:${SERVER_HTTP_PORT}/
 elif [[ $1 == *" "* ]]; then
   e "Invalid hostname: [$1]"
 elif [[ $1 == http?:* ]]; then
-  HOST="$1":8000
-elif [[ $1 == http?:*:* ]]; then
-  HOST="$1"
+  HOST="${1}:${SERVER_HTTP_PORT}"
+elif [[ ${1} == http?:*:* ]]; then
+  SERVER_HTTP_PORT="${${${1#*:}#*:}%%/*}"
+  HOST="${1}"
 elif [[ $1 =~ ^[0-9]+$ ]]; then
+  SERVER_HTTP_PORT="$1"
   HOST=https://localhost:$1/
 else
   e "Invalid hostname or port: [$1]"
 fi
 export HOST
+export SERVER_HTTP_PORT
 
 l "Configuring ${HOST}..."
 


### PR DESCRIPTION
- Let HTTP port be specified instead of requiring port 8000, using SERVER_HTTP_PORT parameter.
  - Also it can be passed as parameter to the dockerfile (first argument)
  - Add more validation to the port number
- Fix some problems with the audit middleware
  - golang middleware should generally match Handler, not HandlerFunc: https://stackoverflow.com/questions/53678633/understanding-the-http-handlerfunc-wrapper-technique-in-go
-  update makefile to properly track the plugins folder contents
- Adds `dev.sh` script for local (host os) development. Please add your environment here; I've been unable to make it really robust so far
- Some other cleanups