### PR TITLE
✅ Better local and CI testing

### DIFF
--- a/.github/workflows/roundtrip/tdf.py
+++ b/.github/workflows/roundtrip/tdf.py
@@ -1,7 +1,6 @@
-import os
 import sys
 import logging
-from opentdf import TDFClient, OIDCCredentials, LogLevel, TDFStorageType
+from opentdf import TDFClient, NanoTDFClient, OIDCCredentials, LogLevel, TDFStorageType
 
 logger = logging.getLogger("xtest")
 logging.basicConfig()
@@ -13,6 +12,7 @@ OIDC_ENDPOINT = "http://localhost:65432"
 KAS_URL = "http://localhost:65432/api/kas"
 REALM = "tdf"
 
+
 def main():
     function, source, target = sys.argv[1:4]
 
@@ -23,8 +23,14 @@ def main():
         organization_name=REALM,
         oidc_endpoint=OIDC_ENDPOINT,
     )
-    client = TDFClient(oidc_credentials=oidc_creds, kas_url=KAS_URL)
-    client.enable_console_logging(LogLevel.Info)
+
+    is_nano = source.endswith(".ntdf") or target.endswith(".ntdf")
+    client = (
+        NanoTDFClient(oidc_credentials=oidc_creds, kas_url=KAS_URL)
+        if is_nano
+        else TDFClient(oidc_credentials=oidc_creds, kas_url=KAS_URL)
+    )
+    client.enable_console_logging(LogLevel.Debug)
 
     if function == "encrypt":
         encrypt_file(client, source, target)
@@ -34,17 +40,20 @@ def main():
         logger.error("Python -- invalid function type provided")
         sys.exit(1)
 
+
 def encrypt_file(client, source, target):
     logger.info(f"Python -- Encrypting file {source} to {target}")
     sampleTxtStorage = TDFStorageType()
     sampleTxtStorage.set_tdf_storage_file_type(source)
     client.encrypt_file(sampleTxtStorage, target)
 
+
 def decrypt_file(client, source, target):
     logger.info(f"Python -- Decrypting file {source} to {target}")
     sampleTdfStorage = TDFStorageType()
     sampleTdfStorage.set_tdf_storage_file_type(source)
     client.decrypt_file(sampleTdfStorage, target)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/roundtrip/wait-and-test.sh
+++ b/.github/workflows/roundtrip/wait-and-test.sh
@@ -33,16 +33,18 @@ if ! _wait-for; then
   exit 1
 fi
 
-rm -rf sample.{out,tdf,txt}
-echo hello-world >sample.txt
-if ! python3 ./tdf.py encrypt sample.txt sample.tdf; then
-  echo ERROR encrypt failure
-  exit 1
-fi
+for e in tdf ntdf; do
+  rm -rf sample.{out,{n,}tdf,txt}
+  echo "hello-world ${e} sample plaintext" >sample.txt
+  if ! python3 ./tdf.py encrypt sample.txt "sample.${e}"; then
+    echo ERROR encrypt ${e} failure
+    exit 1
+  fi
 
-if ! python3 ./tdf.py decrypt sample.tdf sample.out; then
-  echo ERROR decrypt failure
-  exit 1
-fi
+  if ! python3 ./tdf.py decrypt "sample.${e}" sample.out; then
+    echo ERROR decrypt ${e} failure
+    exit 1
+  fi
 
-echo INFO Successful round trip!
+  echo INFO Successful ${e} round trip!
+done

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,13 @@
 
 load("./opentdf.Tiltfile", "opentdf_cluster_with_ingress")
 
-opentdf_cluster_with_ingress(start_frontend=False)
+# Ingress host port
+INGRESS_HOST_PORT = os.getenv("OPENTDF_INGRESS_HOST_PORT", "65432")
+
+opentdf_cluster_with_ingress(
+    external_port=INGRESS_HOST_PORT,
+    start_frontend=False,
+)
 
 # ability to pass in custom test script with path to script as env var
 # e.g.: CI=1 TEST_SCRIPT=tests/wait-and-test.sh tilt up

--- a/cmd/microservice/main.go
+++ b/cmd/microservice/main.go
@@ -215,8 +215,8 @@ func main() {
 	kas := access.Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -319,10 +319,9 @@ func main() {
 		slog.Error("public key RSA cert error")
 		panic("public key RSA cert error")
 	}
-	kas.PublicKeyRsa = *rsaPublicKey
+	kas.PublicKeyRSA = *rsaPublicKey
 
 	// EC Cert
-	var ecCert x509.Certificate
 	ecLabel := os.Getenv("PKCS11_LABEL_PUBKEY_EC") // development-ec-kas
 	certECHandle, err := findKey(hs, pkcs11.CKO_CERTIFICATE, keyID, ecLabel)
 	if err != nil {
@@ -351,17 +350,17 @@ func main() {
 				slog.Error("x509 parse error", "err", err)
 				panic(err)
 			}
-			ecCert = *certEC
+			kas.CertificateEC = *certEC
 		}
 	}
 
 	// EC Public Key
-	ecPublicKey, ok := ecCert.PublicKey.(*ecdsa.PublicKey)
+	ecPublicKey, ok := kas.CertificateEC.PublicKey.(*ecdsa.PublicKey)
 	if !ok {
 		slog.Error("public key from cert fail for EC")
 		panic("EC parse fail")
 	}
-	kas.PublicKeyEc = *ecPublicKey
+	kas.PublicKeyEC = *ecPublicKey
 
 	auditHook := loadAuditHook()
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean test
 
-all: gokas
+all: gokas go-plugins
 go-plugins: plugins/audit_hooks.so
 
 GO_MOD_LINE = $(shell head -n 1 go.mod | cut -c 8-)

--- a/opentdf.Tiltfile
+++ b/opentdf.Tiltfile
@@ -10,8 +10,6 @@ load("ext://restart_process", "docker_build_with_restart")
 
 min_tilt_version("0.31")
 
-EXTERNAL_URL = "http://localhost:65432"
-
 # Versions of things backend to pull (attributes, kas, etc)
 BACKEND_CHART_TAG = os.environ.get("BACKEND_LATEST_VERSION", "0.0.0-sha-02d27b5")
 FRONTEND_CHART_TAG = os.environ.get("FRONTEND_LATEST_VERSION", "1.4.1")
@@ -63,7 +61,7 @@ docker_build(
 )
 
 
-def ingress():
+def ingress(external_port="65432"):
     helm_repo(
         "k8s-in",
         "https://kubernetes.github.io/ingress-nginx",
@@ -83,7 +81,7 @@ def ingress():
             }
         ),
         labels="third-party",
-        port_forwards="65432:80",
+        port_forwards="{}:80".format(external_port),
         resource_deps=["k8s-in"],
     )
 
@@ -134,8 +132,8 @@ def frontend(values=[], set={}, resource_deps=[]):
     # resource("abacus", labels="opentdf", resource_deps=resource_deps)
 
 
-def opentdf_cluster_with_ingress(start_frontend=True):
-    ingress()
+def opentdf_cluster_with_ingress(external_port=65432, start_frontend=True):
+    ingress(external_port=external_port)
 
     backend(
         set={

--- a/pkg/access/provider.go
+++ b/pkg/access/provider.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Provider struct {
-	URI          url.URL `json:"uri"`
-	PrivateKey   p11.Pkcs11PrivateKeyRSA
-	PublicKeyRsa rsa.PublicKey `json:"publicKey"`
-	PublicKeyEc  ecdsa.PublicKey
-	Certificate  x509.Certificate `json:"certificate"`
-	Attributes   []Attribute      `json:"attributes"`
-	Session      p11.Pkcs11Session
-	OIDCVerifier *oidc.IDTokenVerifier
+	URI           url.URL `json:"uri"`
+	PrivateKey    p11.Pkcs11PrivateKeyRSA
+	PublicKeyRSA  rsa.PublicKey `json:"publicKey"`
+	PublicKeyEC   ecdsa.PublicKey
+	Certificate   x509.Certificate `json:"certificate"`
+	CertificateEC x509.Certificate `json:"certificateEc"`
+	Attributes    []Attribute      `json:"attributes"`
+	Session       p11.Pkcs11Session
+	OIDCVerifier  *oidc.IDTokenVerifier
 }

--- a/pkg/access/publicKey.go
+++ b/pkg/access/publicKey.go
@@ -28,7 +28,15 @@ func (p *Provider) CertificateHandler(w http.ResponseWriter, r *http.Request) {
 			slog.ErrorContext(ctx, "EC public key from PKCS11", "err", err)
 			panic(err)
 		}
-		_, _ = w.Write([]byte(eccPem))
+		jData, err := json.Marshal(eccPem)
+		if err != nil {
+			slog.ErrorContext(ctx, "json EC certificate Marshal fail", "err", err)
+			http.Error(w, "configuration error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jData)
+		_, _ = w.Write([]byte("\n"))
 		return
 	}
 	certificatePem, err := exportCertificateAsPemStr(&p.Certificate)

--- a/pkg/access/publicKey.go
+++ b/pkg/access/publicKey.go
@@ -23,12 +23,12 @@ func (p *Provider) CertificateHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	algorithm := r.URL.Query().Get("algorithm")
 	if algorithm == algorithmEc256 {
-		ecPublicKeyPem, err := exportEcPublicKeyAsPemStr(&p.PublicKeyEc)
+		eccPem, err := exportCertificateAsPemStr(&p.CertificateEC)
 		if err != nil {
 			slog.ErrorContext(ctx, "EC public key from PKCS11", "err", err)
 			panic(err)
 		}
-		_, _ = w.Write([]byte(ecPublicKeyPem))
+		_, _ = w.Write([]byte(eccPem))
 		return
 	}
 	certificatePem, err := exportCertificateAsPemStr(&p.Certificate)
@@ -55,7 +55,7 @@ func (p *Provider) PublicKeyHandlerV2(w http.ResponseWriter, r *http.Request) {
 	algorithm := r.URL.Query().Get("algorithm")
 	// ?algorithm=ec:secp256r1
 	if algorithm == algorithmEc256 {
-		ecPublicKeyPem, err := exportEcPublicKeyAsPemStr(&p.PublicKeyEc)
+		ecPublicKeyPem, err := exportEcPublicKeyAsPemStr(&p.PublicKeyEC)
 		if err != nil {
 			http.Error(w, "configuration error", http.StatusInternalServerError)
 			slog.ErrorContext(ctx, "EC public key from PKCS11", "err", err)
@@ -67,7 +67,7 @@ func (p *Provider) PublicKeyHandlerV2(w http.ResponseWriter, r *http.Request) {
 	format := r.URL.Query().Get("format")
 	if format == "jwk" {
 		// Parse, serialize, slice and dice JWKs!
-		rsaPublicKeyJwk, err := jwk.FromRaw(&p.PublicKeyRsa)
+		rsaPublicKeyJwk, err := jwk.FromRaw(&p.PublicKeyRSA)
 		if err != nil {
 			http.Error(w, "configuration error", http.StatusInternalServerError)
 			slog.ErrorContext(ctx, "failed to parse JWK", "err", err)
@@ -84,7 +84,7 @@ func (p *Provider) PublicKeyHandlerV2(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(jsonPublicKey)
 		return
 	}
-	rsaPublicKeyPem, err := exportRsaPublicKeyAsPemStr(&p.PublicKeyRsa)
+	rsaPublicKeyPem, err := exportRsaPublicKeyAsPemStr(&p.PublicKeyRSA)
 	if err != nil {
 		http.Error(w, "configuration error", http.StatusInternalServerError)
 		slog.ErrorContext(ctx, "export RSA public key", "err", err)

--- a/pkg/access/publicKey_test.go
+++ b/pkg/access/publicKey_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"github.com/opentdf/backend-go/pkg/p11"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +16,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/opentdf/backend-go/pkg/p11"
 )
 
 func TestExportRsaPublicKeyAsPemStrSuccess(t *testing.T) {
@@ -141,8 +142,8 @@ func TestCertificateHandler(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -171,8 +172,8 @@ func TestCertificateHandlerWithEc256(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  privateKey.PublicKey,
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -182,8 +183,8 @@ func TestCertificateHandlerWithEc256(t *testing.T) {
 	kas.CertificateHandler(response, request)
 	result := response.Body.String()
 
-	if !strings.Contains(result, "BEGIN PUBLIC KEY") {
-		t.Errorf("got %s, but should be pubkey", result)
+	if !strings.Contains(result, "BEGIN CERTIFICATE") {
+		t.Errorf("got %s, but should be cert", result)
 	}
 }
 
@@ -206,8 +207,8 @@ func TestPublicKeyHandlerV2(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: mockPublicKeyRsa,
-		PublicKeyEc:  privateKey.PublicKey,
+		PublicKeyRSA: mockPublicKeyRsa,
+		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -236,8 +237,8 @@ func TestPublicKeyHandlerV2Failure(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  privateKey.PublicKey,
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -271,8 +272,8 @@ func TestPublicKeyHandlerV2WithEc256(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: mockPublicKeyRsa,
-		PublicKeyEc:  privateKey.PublicKey,
+		PublicKeyRSA: mockPublicKeyRsa,
+		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -305,8 +306,8 @@ func TestPublicKeyHandlerV2WithJwk(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: mockPublicKeyRsa,
-		PublicKeyEc:  privateKey.PublicKey,
+		PublicKeyRSA: mockPublicKeyRsa,
+		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},

--- a/pkg/access/rewrap_test.go
+++ b/pkg/access/rewrap_test.go
@@ -5,12 +5,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
-	"github.com/opentdf/backend-go/pkg/p11"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/opentdf/backend-go/pkg/p11"
 )
 
 func TestHandlerEmptyRequestFailure(t *testing.T) {
@@ -23,8 +24,8 @@ func TestHandlerEmptyRequestFailure(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -50,8 +51,8 @@ func TestHandlerAuthFailure0(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -78,8 +79,8 @@ func TestHandlerAuthFailure1(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
@@ -107,8 +108,8 @@ func TestHandlerAuthFailure2(t *testing.T) {
 	kas := Provider{
 		URI:          *kasURI,
 		PrivateKey:   p11.Pkcs11PrivateKeyRSA{},
-		PublicKeyRsa: rsa.PublicKey{},
-		PublicKeyEc:  ecdsa.PublicKey{},
+		PublicKeyRSA: rsa.PublicKey{},
+		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
 		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},


### PR DESCRIPTION
- Adds the `OPENTDF_INGRESS_HOST_PORT` environment variable, useful for configuring access to the local cluster
- Adds a nanotdf pass to the GitHub CI `test-backend` step
- Adds support for EC Certs in kas_public_key endpoint