### PR TITLE
🐛 Fix attribute authority lookup

### DIFF
--- a/.github/workflows/roundtrip/tdf.py
+++ b/.github/workflows/roundtrip/tdf.py
@@ -6,22 +6,17 @@ logger = logging.getLogger("xtest")
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
-CLIENT_ID = "tdf-client"
-CLIENT_SECRET = "123-456"
-OIDC_ENDPOINT = "http://localhost:65432"
 KAS_URL = "http://localhost:65432/api/kas"
-REALM = "tdf"
-
 
 def main():
     function, source, target = sys.argv[1:4]
 
     oidc_creds = OIDCCredentials()
     oidc_creds.set_client_credentials_client_secret(
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
-        organization_name=REALM,
-        oidc_endpoint=OIDC_ENDPOINT,
+        client_id="tdf-client",
+        client_secret="123-456",
+        organization_name="tdf",
+        oidc_endpoint="http://localhost:65432",
     )
 
     is_nano = source.endswith(".ntdf") or target.endswith(".ntdf")
@@ -31,6 +26,10 @@ def main():
         else TDFClient(oidc_credentials=oidc_creds, kas_url=KAS_URL)
     )
     client.enable_console_logging(LogLevel.Debug)
+    client.add_data_attribute(
+        "https://example.com/attr/Classification/value/S", KAS_URL
+    )
+    client.add_data_attribute("https://example.com/attr/COI/value/PRX", KAS_URL)
 
     if function == "encrypt":
         encrypt_file(client, source, target)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,23 @@ ctlptl create cluster kind --registry=ctlptl-registry
 ctlptl delete cluster kind-kind
 ```
 
-### Install ingress
+### Running service in k8s
+
+Quick
+
+```shell
+tilt up
+```
+
+With Test Script:
+
+```shell
+TEST_SCRIPT=.github/workflows/roundtrip/wait-and-test.sh CI=1 tilt up
+```
+
+### Running in host OS
+
+#### Install ingress
 
 ```shell
 helm repo add nginx-stable https://helm.nginx.com/stable
@@ -45,7 +61,7 @@ helm repo update
 helm install ex nginx-stable/nginx-ingress
 ```
 
-### Start database
+#### Start database
 
 ```shell
 mkdir -p data
@@ -58,9 +74,9 @@ docker run \
     postgres
 ```
 
-### Start HSM
+#### Start HSM
 
-#### SoftHSM C Module
+##### SoftHSM C Module
 
 https://wiki.opendnssec.org/display/SoftHSMDOCS/SoftHSM+Documentation+v2
 
@@ -76,7 +92,7 @@ export PKCS11_MODULE_PATH=/opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsoft
 brew install opensc
 ```
 
-#### SoftHSM Keys
+##### SoftHSM Keys
 
 ```shell
 # enter two sets of PIN, 12345
@@ -97,10 +113,12 @@ pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-private.p
 pkcs11-tool --module $PKCS11_MODULE_PATH --login --write-object kas-ec-cert.pem --type cert  --label development-ec-kas
 ```
 
-### Start services
+#### Start services
+
+Manually disable KAS in the tiltfile, if desired, then:
 
 ```shell
-tilt up
+tilt up 
 ```
 
 ### Start monolith service (outside kubernetes)

--- a/cmd/microservice/main_test.go
+++ b/cmd/microservice/main_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+
+	"github.com/opentdf/backend-go/pkg/access"
 )
 
 func TestInferLoggerDefaults(t *testing.T) {
@@ -86,15 +88,15 @@ func TestValidatePort(t *testing.T) {
 		t.Error("empty SERVER_PORT should default properly")
 	}
 	p, err = validatePort("invalid")
-	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+	if p != 0 || !errors.Is(err, access.ErrConfig) {
 		t.Error("invalid error code")
 	}
 	p, err = validatePort("-1000")
-	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+	if p != 0 || !errors.Is(err, access.ErrConfig) {
 		t.Error("invalid error code")
 	}
 	p, err = validatePort("65536")
-	if p != 0 || !errors.Is(err, ErrInvalidPort) {
+	if p != 0 || !errors.Is(err, access.ErrConfig) {
 		t.Error("invalid error code")
 	}
 }

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/opentdf/backend-go/pkg/access"
-	"golang.org/x/exp/slog"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/pkg/access/fetchAttributes.go
+++ b/pkg/access/fetchAttributes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/virtru/access-pdp/attributes"
 )
@@ -17,13 +18,27 @@ const (
 	ErrAttributeDefinitionsServiceCall = Error("attribute definitions service call unexpected")
 )
 
-// const attributeHost = "http://attributes:4020"
-const attributeHost = "http://localhost:65432/api/attributes"
+func ResolveAttributeAuthority(s string) (*url.URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		slog.Error("invalid attribute authority", "err", err)
+		return nil, errors.Join(ErrConfig, err)
+	}
+	if u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		slog.Error("invalid attribute authority", "url", u)
+		return nil, ErrConfig
+	}
+	r, err := u.Parse("v1/attrName")
+	if err != nil {
+		panic(err)
+	}
+	return r, nil
+}
 
-func fetchAttributes(ctx context.Context, namespaces []string) ([]attributes.AttributeDefinition, error) {
+func (p *Provider) fetchAttributes(ctx context.Context, namespaces []string) ([]attributes.AttributeDefinition, error) {
 	var definitions []attributes.AttributeDefinition
 	for _, ns := range namespaces {
-		attrDefs, err := fetchAttributesForNamespace(ctx, ns)
+		attrDefs, err := p.fetchAttributesForNamespace(ctx, ns)
 		if err != nil {
 			slog.ErrorContext(ctx, "unable to fetch attributes for namespace", "err", err, "namespace", ns)
 			return nil, err
@@ -33,11 +48,11 @@ func fetchAttributes(ctx context.Context, namespaces []string) ([]attributes.Att
 	return definitions, nil
 }
 
-func fetchAttributesForNamespace(ctx context.Context, namespace string) ([]attributes.AttributeDefinition, error) {
+func (p *Provider) fetchAttributesForNamespace(ctx context.Context, namespace string) ([]attributes.AttributeDefinition, error) {
 	slog.DebugContext(ctx, "Fetching", "namespace", namespace)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, attributeHost+"/v1/attrName", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.AttributeSvc.String(), nil)
 	if err != nil {
-		slog.ErrorContext(ctx, "unable to create http request to attributes service", "namespace", namespace, "attributeHost", attributeHost)
+		slog.ErrorContext(ctx, "unable to create http request to attributes service", "namespace", namespace, "attributeHost", p.AttributeSvc)
 		return nil, errors.Join(ErrAttributeDefinitionsServiceCall, err)
 	}
 
@@ -49,13 +64,13 @@ func fetchAttributesForNamespace(ctx context.Context, namespace string) ([]attri
 	var httpClient http.Client
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed http request to attributes service", "err", err, "namespace", namespace, "attributeHost", attributeHost, "req.URL", req.URL)
+		slog.ErrorContext(ctx, "failed http request to attributes service", "err", err, "namespace", namespace, "req.URL", req.URL)
 		return nil, errors.Join(ErrAttributeDefinitionsServiceCall, err)
 	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to close http request to attributes service", "err", err, "namespace", namespace, "attributeHost", attributeHost, "req", req)
+			slog.ErrorContext(ctx, "failed to close http request to attributes service", "err", err, "namespace", namespace, "req.URL", req.URL)
 		}
 	}(resp.Body)
 	if resp.StatusCode != http.StatusOK {
@@ -66,7 +81,7 @@ func fetchAttributesForNamespace(ctx context.Context, namespace string) ([]attri
 	var definitions []attributes.AttributeDefinition
 	err = json.NewDecoder(resp.Body).Decode(&definitions)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to parse response from attributes service", "err", err, "namespace", namespace, "attributeHost", attributeHost, "req", req)
+		slog.ErrorContext(ctx, "failed to parse response from attributes service", "err", err, "namespace", namespace, "req.URL", req.URL)
 		return nil, errors.Join(ErrAttributeDefinitionsUnmarshal, err)
 	}
 

--- a/pkg/access/fetchAttributes.go
+++ b/pkg/access/fetchAttributes.go
@@ -49,7 +49,7 @@ func fetchAttributesForNamespace(ctx context.Context, namespace string) ([]attri
 	var httpClient http.Client
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed http request to attributes service", "err", err, "namespace", namespace, "attributeHost", attributeHost, "req", req)
+		slog.ErrorContext(ctx, "failed http request to attributes service", "err", err, "namespace", namespace, "attributeHost", attributeHost, "req.URL", req.URL)
 		return nil, errors.Join(ErrAttributeDefinitionsServiceCall, err)
 	}
 	defer func(Body io.ReadCloser) {

--- a/pkg/access/provider.go
+++ b/pkg/access/provider.go
@@ -10,6 +10,11 @@ import (
 	"github.com/opentdf/backend-go/pkg/p11"
 )
 
+const (
+	ErrHSM    = Error("hsm unexpected")
+	ErrConfig = Error("invalid port")
+)
+
 type Provider struct {
 	AccessServiceServer
 	URI           url.URL `json:"uri"`
@@ -18,7 +23,7 @@ type Provider struct {
 	PublicKeyEC   ecdsa.PublicKey
 	Certificate   x509.Certificate `json:"certificate"`
 	CertificateEC x509.Certificate `json:"certificateEc"`
-	Attributes    []Attribute      `json:"attributes"`
+	AttributeSvc  *url.URL
 	Session       p11.Pkcs11Session
 	OIDCVerifier  *oidc.IDTokenVerifier
 }

--- a/pkg/access/publicKey_test.go
+++ b/pkg/access/publicKey_test.go
@@ -141,7 +141,6 @@ func TestCertificateHandler(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -170,7 +169,6 @@ func TestCertificateHandlerWithEc256(t *testing.T) {
 		PublicKeyEC:   privateKey.PublicKey,
 		Certificate:   x509.Certificate{},
 		CertificateEC: x509.Certificate{},
-		Attributes:    nil,
 		Session:       p11.Pkcs11Session{},
 		OIDCVerifier:  nil,
 	}
@@ -198,7 +196,7 @@ func TestPublicKeyHandlerWithEc256(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -231,7 +229,7 @@ func TestPublicKeyHandlerV2(t *testing.T) {
 		PublicKeyRSA: mockPublicKeyRsa,
 		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -259,7 +257,7 @@ func TestPublicKeyHandlerV2Failure(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -288,7 +286,7 @@ func TestPublicKeyHandlerV2WithEc256(t *testing.T) {
 		PublicKeyRSA: mockPublicKeyRsa,
 		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -321,7 +319,7 @@ func TestPublicKeyHandlerV2WithJwk(t *testing.T) {
 		PublicKeyRSA: mockPublicKeyRsa,
 		PublicKeyEC:  privateKey.PublicKey,
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}

--- a/pkg/access/rewrap.go
+++ b/pkg/access/rewrap.go
@@ -165,8 +165,8 @@ func (p *Provider) Rewrap(ctx context.Context, in *RewrapRequest) (*RewrapRespon
 	}
 
 	// this part goes in the plugin?
-	slog.DebugContext(ctx, "Fetching attributes")
-	definitions, err := fetchAttributes(ctx, namespaces)
+	slog.DebugContext(ctx, "Fetching attributes", "policy.namespaces", namespaces, "policy.body", policy.Body)
+	definitions, err := p.fetchAttributes(ctx, namespaces)
 	if err != nil {
 		slog.ErrorContext(ctx, "Could not fetch attribute definitions from attributes service!", "err", err)
 		return nil, status.Error(codes.Internal, "attribute server request failure")

--- a/pkg/access/rewrap_test.go
+++ b/pkg/access/rewrap_test.go
@@ -22,7 +22,7 @@ func TestHandlerAuthFailure0(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -43,7 +43,7 @@ func TestHandlerAuthFailure1(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}
@@ -68,7 +68,7 @@ func TestHandlerAuthFailure2(t *testing.T) {
 		PublicKeyRSA: rsa.PublicKey{},
 		PublicKeyEC:  ecdsa.PublicKey{},
 		Certificate:  x509.Certificate{},
-		Attributes:   nil,
+
 		Session:      p11.Pkcs11Session{},
 		OIDCVerifier: nil,
 	}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -28,8 +28,6 @@
 #     - Public key KAS clients can use to validate responses.
 #   ATTR_AUTHORITY_HOST
 #     - OpenTDF Attribute service host, or other compliant authority
-#   ATTR_AUTHORITY_CERTIFICATE
-#     - The public key used to validate responses from ATTR_AUTHORITY_HOST.
 #   LOG_LEVEL
 #     - `slog` level. Defaults to `info`. Other options include
 #       `debug` (more verbose) and `warn` (less verbose)
@@ -59,6 +57,8 @@
 #   CLIENT_KEY_PATH
 #   V2_SAAS_ENABLED
 #   LEGACY_NANOTDF_IV
+#   ATTR_AUTHORITY_CERTIFICATE
+#     - The public key used to validate responses from ATTR_AUTHORITY_HOST. Not used in OIDC mode
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPTS_DIR}/../" >/dev/null && pwd | sed 's:/*$::')"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,7 +12,7 @@
 #   SERVER_HTTP_PORT
 #     - The port to serve the HTTP REST endpoint on
 #   OIDC_ISSUER_URL
-#     - The URL prefix to check for ISSUER. Also used for oidc discovery, 
+#     - The URL prefix to check for ISSUER. Also used for oidc discovery,
 #       unless overridden by OIDC_DISCOVERY_BASE_URL
 #   PKCS11_PIN
 #     - SECRET
@@ -87,7 +87,9 @@ elif [[ $1 == *" "* ]]; then
 elif [[ $1 == http?:* ]]; then
   HOST="${1}:${SERVER_HTTP_PORT}"
 elif [[ ${1} == http?:*:* ]]; then
-  SERVER_HTTP_PORT="${${${1#*:}#*:}%%/*}"
+  p1="${1#*:}"
+  p2="${p1#*:}"
+  SERVER_HTTP_PORT="${p2%%/*}"
   HOST="${1}"
 elif [[ $1 =~ ^[0-9]+$ ]]; then
   SERVER_HTTP_PORT="$1"


### PR DESCRIPTION
- Adds a data attribute to the round-trip test, mimicking the test in quickstart
- This triggered a 500 due to the attribute authority being hardcoded to localhost, so...
- Parse ATTR_AUTHORITY_HOST environment variable
- Use this in the fetchAttributes function
- Some minor cleanups for error reporting