### PR TITLE
fix(rewrap): Removes KAO URI check

### DIFF
--- a/pkg/access/rewrap.go
+++ b/pkg/access/rewrap.go
@@ -241,8 +241,7 @@ func (p *Provider) Rewrap(ctx context.Context, in *RewrapRequest) (*RewrapRespon
 	}
 
 	if !strings.HasPrefix(body.requestBody.KeyAccess.URL, p.URI.String()) {
-		slog.WarnContext(ctx, "invalid key access url", "keyAccessURL", body.requestBody.KeyAccess.URL, "kasURL", p.URI.String())
-		return nil, err403("forbidden")
+		slog.InfoContext(ctx, "mismatched key access url", "keyAccessURL", body.requestBody.KeyAccess.URL, "kasURL", p.URI.String())
 	}
 
 	if body.requestBody.Algorithm == "" {


### PR DESCRIPTION
- This was notionally to help prevent KAS A from trying to decrypt KAOs for KAS B, which may have different policies
- But given they will have different keys, this shouldn't matter